### PR TITLE
HTTPS Endpoint to remove Post errors

### DIFF
--- a/StrawPollNET/Internal/Calls.cs
+++ b/StrawPollNET/Internal/Calls.cs
@@ -9,7 +9,7 @@ namespace StrawPollNET.Internal
 {
     internal static class Calls
     {
-        private static string apiEndpoint = "http://www.strawpoll.me/api/v2/polls";
+        private static string apiEndpoint = "https://www.strawpoll.me/api/v2/polls";
 
         public static async Task<FetchedPoll> GetPoll(int pollId)
         {


### PR DESCRIPTION
Documentation from the Starpoll API (https://github.com/strawpoll/strawpoll/wiki/API) defines the API endpoint with HTTPS instead of HTTP. This resolves issue #1